### PR TITLE
light README and train parameter changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ $ THEANORC=theanorc scripts/adjust_population_statistics \
   celeba_vae_regularization.zip celeba_vae_regularization_adjusted.zip
 ```
 
+Note: If you run out of memory in training, a good workaround is to reduce the
+`training_batch_size` and `monitoring_batch_size`.
+
 ## Evaluating the models
 
 ### Samples
@@ -148,6 +151,12 @@ $ THEANORC=theanorc scripts/interpolate celeba celeba_vae_regularization_adjuste
 ```
 
 ![CelebA interpolations](example_figures/celeba_vae_regularization_interpolations.png)
+
+Note: All evaluation scripts use ipython. But this behavior can be overridden by explicitly using python on the command line along with a save path. For example:
+
+```
+THEANORC=theanorc python scripts/sample --save-path sample_no_reg.png celeba_vae_no_regularization.zip
+```
 
 ### NLL approximation
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ $ fuel-download cifar10 --clear
 Download the CelebA dataset:
 
 ``` bash
-$ fuel-download celeba 64
+$ fuel-download celeba
 $ fuel-convert celeba 64
-$ fuel-download celeba 64 --clear
+$ fuel-download celeba --clear
 ```
 
 ## Training the models


### PR DESCRIPTION
Two small and independent tweaks:
- The only small error I found getting things going was in the README - fuel-download doesn't need the size parameter, only fuel-convert does.
- Because training the CelebA classifier is so fast, I thought dropping the checkpointing and monitoring to every epoch made sense.

Also I'll use this space to note a few other things that might help others get started.

The packaged theanorc didn't work for me because I had some custom variables I needed (cuda root). But having the packaged template was good - it was easy to add my own variables to a copy and use that instead.

I also had to prepend all commands with `PYTHONPATH=.` to get imports to work.

I ran out of GPU memory training the VAE with discriminative regularization, but lowering the batch sizes was an effective workaround.

Since I was running this remotely, it wasn't clear why the `scripts` (like sample and reconstruct) were hanging indefinitely - then I checked and saw that it was using ipython. The code is already written to allow command line usage, the invocation is just different - use `python` explicitly and a `--save-path`:

```
THEANORC=theanorc.mine PYTHONPATH=. python scripts/sample --save-path sample_no_reg.png celeba_vae_no_regularization.zip
```
