### PR TITLE
Celeba changes

### DIFF
--- a/experiments/train_celeba_classifier.py
+++ b/experiments/train_celeba_classifier.py
@@ -106,7 +106,7 @@ def create_training_computation_graphs():
     return cg, bn_dropout_cg
 
 
-def run(batch_size, classifier, allowed):
+def run(batch_size, classifier, monitor_every, checkpoint_every, allowed):
     streams = create_celeba_streams(training_batch_size=batch_size,
                                     monitoring_batch_size=batch_size,
                                     include_targets=True,
@@ -145,10 +145,10 @@ def run(batch_size, classifier, allowed):
     monitored_quantities = [cost, accuracy]
     valid_monitoring = DataStreamMonitoring(
         monitored_quantities, valid_monitor_stream, prefix="valid",
-        before_first_epoch=False, after_epoch=False, every_n_epochs=5)
+        before_first_epoch=False, after_epoch=False, every_n_epochs=monitor_every)
 
     # Prepare checkpoint
-    checkpoint = Checkpoint(classifier, every_n_epochs=5, use_cpickle=True)
+    checkpoint = Checkpoint(classifier, every_n_epochs=checkpoint_every, use_cpickle=True)
 
     extensions = [Timing(), FinishAfter(after_n_epochs=50), train_monitoring,
                   valid_monitoring, checkpoint, Printing(), ProgressBar()]
@@ -166,8 +166,12 @@ if __name__ == "__main__":
                 help="Only allow whitelisted labels L1,L2,...")
     parser.add_argument("--batch-size", type=int, dest="batch_size",
                 default=100, help="Size of each mini-batch")
+    parser.add_argument("--monitor-every", type=int, dest="monitor_every",
+                default=5, help="Frequency in epochs for monitoring")
+    parser.add_argument("--checkpoint-every", type=int, dest="checkpoint_every",
+                default=5, help="Frequency in epochs for checkpointing")
     args = parser.parse_args()
     allowed = None
     if(args.allowed):
         allowed = map(int, args.allowed.split(","))
-    run(args.batch_size, args.classifier, allowed)
+    run(args.batch_size, args.classifier, args.monitor_every, args.checkpoint_every, allowed)

--- a/experiments/train_celeba_classifier.py
+++ b/experiments/train_celeba_classifier.py
@@ -106,10 +106,11 @@ def create_training_computation_graphs():
     return cg, bn_dropout_cg
 
 
-def run():
-    streams = create_celeba_streams(training_batch_size=100,
-                                    monitoring_batch_size=500,
-                                    include_targets=True)
+def run(batch_size, classifier, allowed):
+    streams = create_celeba_streams(training_batch_size=batch_size,
+                                    monitoring_batch_size=batch_size,
+                                    include_targets=True,
+                                    allowed=allowed)
     main_loop_stream = streams[0]
     train_monitor_stream = streams[1]
     valid_monitor_stream = streams[2]
@@ -147,8 +148,7 @@ def run():
         before_first_epoch=False, after_epoch=False, every_n_epochs=5)
 
     # Prepare checkpoint
-    checkpoint = Checkpoint(
-        'celeba_classifier.zip', every_n_epochs=5, use_cpickle=True)
+    checkpoint = Checkpoint(classifier, every_n_epochs=5, use_cpickle=True)
 
     extensions = [Timing(), FinishAfter(after_n_epochs=50), train_monitoring,
                   valid_monitoring, checkpoint, Printing(), ProgressBar()]
@@ -161,5 +161,13 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(
         description="Train a classifier on the CelebA dataset")
+    parser.add_argument('--classifier', dest='classifier', type=str, default="celeba_classifier.zip")
+    parser.add_argument("--allowed", dest='allowed', type=str, default=None,
+                help="Only allow whitelisted labels L1,L2,...")
+    parser.add_argument("--batch-size", type=int, dest="batch_size",
+                default=100, help="Size of each mini-batch")
     args = parser.parse_args()
-    run()
+    allowed = None
+    if(args.allowed):
+        allowed = map(int, args.allowed.split(","))
+    run(args.batch_size, args.classifier, allowed)


### PR DESCRIPTION
I've made some changes to the celeba classifer and vae experiment, some of which might be generally useful. I'm posting all of the changes here for discussion.  There is some tension here between having a small and easy to understand example to support the paper and having a general purpose tool for further experiments. So I'm also happy to maintain this functionality in my own repo, perhaps split out in separate files.

That said, here's the changes in these commits:
- Added a bunch of command line options for things that were hard coded like
  - --classifier to use a different classifier filename
  - --model to use a different model filename
  - --batch-size to use different batch-sizes (generally smaller for memory reasons)
  - --z-dim to change network architecture allowing different sized latent space
  - --monitor-every and --checkpoint-every to change frequency of those events
- Split out `discriminative_term` in the cost function so it could be monitored separately (9565843)
- Ability to scale relative cost of reconstruction, kl, and discriminative (d9afe52)
- Classifier can train on a subset of labels given at runtime (dee459a)
- Can train against compatible fuel datasets other than CelebA (779d587)

Happy to discuss any of these that might be useful to clean up into a separate pull request.
